### PR TITLE
Updated admin main news dialog. Fixed document order bug on custom pages

### DIFF
--- a/src/assets/svg/Icons/Close.svg
+++ b/src/assets/svg/Icons/Close.svg
@@ -1,0 +1,5 @@
+<svg width="800px" height="800px" viewBox="-0.5 0 25 25" fill="currentcolor"
+  xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 21.32L21 3.32001" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M3 3.32001L21 21.32" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/AdminDocumentsForm.vue
+++ b/src/components/AdminDocumentsForm.vue
@@ -5,6 +5,11 @@
         <TableMover :ordered-items="documentType.pageSectionDocuments" :index="scope.$index" />
       </template>
     </el-table-column>
+    <el-table-column width="50" label="№" align="center">
+      <template #default="scope">
+        {{ scope.row.order + 1 }}
+      </template>
+    </el-table-column>
     <el-table-column prop="name" label="Название документа">
       <template #default="scope">
         <el-form-item size="mini" style="margin: 0">

--- a/src/components/Main/MainBigNewsCard.vue
+++ b/src/components/Main/MainBigNewsCard.vue
@@ -4,6 +4,7 @@
     :style="{ 'background-image': 'url(' + news.getImageUrl() + ')' }"
     @click="$router.push(`/news/${news.slug}`)"
   >
+    <Close v-if="showClose" class="close-icon" @click.stop="$emit('close')" />
     <div class="big-news-card-container">
       <div class="big-news-card-tags">
         <el-tag
@@ -28,18 +29,24 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 
+import Close from '@/assets/svg/Icons/Close.svg';
 import NewsMeta from '@/components/News/NewsMeta.vue';
 import INews from '@/interfaces/news/INews';
 
 export default defineComponent({
   name: 'MainBigNewsCard',
-  components: { NewsMeta },
+  components: { NewsMeta, Close },
   props: {
     news: {
       type: Object as PropType<INews>,
       required: true,
     },
+    showClose: {
+      type: Boolean,
+      default: false,
+    },
   },
+  emits: ['close'],
 });
 </script>
 
@@ -54,7 +61,9 @@ export default defineComponent({
   color: #343e5c;
   display: flex;
   align-items: flex-end;
+  position: relative;
   &-container {
+    width: 100%;
     background: #ffffff;
     display: flex;
     flex-direction: column;
@@ -216,5 +225,22 @@ export default defineComponent({
       }
     }
   }
+}
+.close-icon {
+  width: 30px;
+  height: 30px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 10px;
+  backdrop-filter: blur(5px);
+  border-radius: 20%;
+  padding: 5px;
+  filter: brightness(100%);
+  z-index: 99;
+}
+.close-icon:hover {
+  backdrop-filter: blur(20px);
+  transform: scale(1.1);
 }
 </style>

--- a/src/components/Main/MainNewsBlock.vue
+++ b/src/components/Main/MainNewsBlock.vue
@@ -15,7 +15,7 @@
         <div class="size"><NewsCard :news="newsSubMain2" :main="true" /></div>
       </div>
       <div class="main-news-block-right">
-        <RecentNewsCard :main="true" :news-number="5" style="height: 100%" />
+        <RecentNewsCard :news-list="recentNewsList" :main="true" :news-number="5" style="height: 100%" />
       </div>
     </div>
   </component>
@@ -43,6 +43,7 @@ export default defineComponent({
     const newsMain = computed(() => Provider.store.getters['news/main']);
     const newsSubMain1 = computed(() => Provider.store.getters['news/subMain1']);
     const newsSubMain2 = computed(() => Provider.store.getters['news/subMain2']);
+    const recentNewsList = computed(() => Provider.store.getters['news/mainPageRecentNewsList']);
     const mounted: Ref<boolean> = ref(false);
 
     const createFilterModels = () => {
@@ -60,12 +61,11 @@ export default defineComponent({
 
     const load = async () => {
       createFilterModels();
-      await Promise.all([
-        Provider.store.dispatch('news/getAll', Provider.filterQuery.value),
-        Provider.store.dispatch('news/getMain'),
-        Provider.store.dispatch('news/getSubMain'),
-      ]);
+      await Provider.store.dispatch('news/getAll', Provider.filterQuery.value);
+      await Provider.store.dispatch('news/getMain', true);
+      await Provider.store.dispatch('news/getSubMain', true);
       Provider.store.commit('news/setFilteredNews');
+      // setNews();
       mounted.value = true;
     };
 
@@ -77,6 +77,7 @@ export default defineComponent({
       newsMain,
       newsSubMain1,
       newsSubMain2,
+      recentNewsList,
     };
   },
 });

--- a/src/components/News/NewsCard.vue
+++ b/src/components/News/NewsCard.vue
@@ -5,6 +5,7 @@
     :body-style="{ padding: '0px', height: '75%' }"
     @click="$router.push(`/news/${news.slug}`)"
   >
+    <Close v-if="showClose" class="close-icon" @click.stop="$emit('close')" />
     <div class="flex-between-columm front">
       <div class="image">
         <img :src="news.getImageUrl()" alt="alt" />
@@ -67,13 +68,14 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 
+import Close from '@/assets/svg/Icons/Close.svg';
 import NewsMeta from '@/components/News/NewsMeta.vue';
 import INews from '@/interfaces/news/INews';
 import ITag from '@/interfaces/news/ITag';
 
 export default defineComponent({
   name: 'NewsCard',
-  components: { NewsMeta },
+  components: { NewsMeta, Close },
   props: {
     news: {
       type: Object as PropType<INews>,
@@ -87,7 +89,12 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    showClose: {
+      type: Boolean,
+      default: false,
+    },
   },
+  emits: ['close'],
   setup() {
     const filterNews = async (tag: ITag): Promise<void> => {
       // tag.selected = !tag.selected;
@@ -337,6 +344,24 @@ $card-width: 300px;
   z-index: 1;
   top: 0;
   left: 0;
+}
+
+.close-icon {
+  width: 20px;
+  height: 20px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 10px;
+  backdrop-filter: blur(5px);
+  border-radius: 20%;
+  padding: 5px;
+  filter: brightness(100%);
+  z-index: 99;
+}
+.close-icon:hover {
+  backdrop-filter: blur(20px);
+  transform: scale(1.1);
 }
 
 // @media screen and (max-width: 980px) {

--- a/src/components/News/NewsPageFooter.vue
+++ b/src/components/News/NewsPageFooter.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="article-footer">
     <div class="top-footer">
-      <div class="date-meta">{{ $dateTimeFormatter.format(news.publishedOn, { month: 'long', hour: 'numeric', minute: 'numeric' }) }}</div>
+      <div class="date-meta">
+        {{
+          $dateTimeFormatter.format(news.publishedOn, {
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric',
+          })
+        }}
+      </div>
       <div class="card-meta">
         <div class="views">
           <EyeOutlined />

--- a/src/components/News/RecentNewsCard.vue
+++ b/src/components/News/RecentNewsCard.vue
@@ -30,7 +30,7 @@
 
 <script lang="ts">
 import { EyeOutlined } from '@ant-design/icons-vue';
-import { computed, defineComponent, onBeforeMount, Ref } from 'vue';
+import { computed, defineComponent, onBeforeMount, PropType, Ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useStore } from 'vuex';
 
@@ -49,25 +49,20 @@ export default defineComponent({
       type: Number,
       default: 3,
     },
+    newsList: {
+      type: Array as PropType<INews[]>,
+      default: () => [],
+    },
   },
 
   setup(props) {
     const store = useStore();
-    const recentNewsList = computed(() =>
-      store.getters['news/news']
-        .filter((item: INews) => {
-          if (props.main) {
-            if (item.id !== news.value.id && !item.main && !item.subMain) {
-              return item;
-            }
-          } else {
-            if (item.id !== news.value.id) {
-              return item;
-            }
-          }
-        })
-        .slice(0, props.newsNumber)
-    );
+    const recentNewsList = computed(() => {
+      if (props.newsList.length) {
+        return props.newsList;
+      }
+      return store.getters['news/news'].filter((item: INews) => item.id !== news.value.id).slice(0, props.newsNumber);
+    });
     const news: Ref<INews> = computed(() => store.getters['news/newsItem']);
     const router = useRouter();
 

--- a/src/components/RemoteSearch.vue
+++ b/src/components/RemoteSearch.vue
@@ -73,9 +73,13 @@ export default defineComponent({
       type: [Number, String],
       default: 300,
     },
+    clearAfterSelect: {
+      type: Boolean,
+      default: true,
+    },
   },
   emits: ['select', 'load', 'input'],
-  setup(props, { emit }) {
+  setup(props, { emit, expose }) {
     const queryString: Ref<string> = ref(props.modelValue);
     const searchForm = ref();
     const searchModel: Ref<SearchModel> = computed<SearchModel>(() => Provider.store.getters['search/searchModel']);
@@ -114,8 +118,10 @@ export default defineComponent({
         await Provider.store.dispatch(`${props.storeModule}/getAllById`, item.id);
         return;
       }
-      emit('select', item);
-      queryString.value = '';
+      await emit('select', item);
+      if (props.clearAfterSelect) {
+        queryString.value = '';
+      }
     };
 
     const createModel = (): IFilterModel => {
@@ -139,6 +145,12 @@ export default defineComponent({
         emit('input', '');
       }
     };
+
+    const clearSearch = () => {
+      queryString.value = '';
+    };
+
+    expose({ clear: clearSearch });
 
     return { searchForm, onEnter, queryString, handleSelect, find, handleSearchInput, handleInput };
   },

--- a/src/services/classes/page/PageSection.ts
+++ b/src/services/classes/page/PageSection.ts
@@ -29,7 +29,9 @@ export default class PageSection {
   }
 
   addDocument(): void {
-    this.pageSectionDocuments.push(new PageSectionDocument());
+    const newDoc = new PageSectionDocument();
+    newDoc.order = this.pageSectionDocuments.length - 1;
+    this.pageSectionDocuments.push(newDoc);
   }
 
   getFileInfos(): IFileInfo[] {

--- a/src/services/classes/page/PageSideMenu.ts
+++ b/src/services/classes/page/PageSideMenu.ts
@@ -10,6 +10,7 @@ export default class PageSideMenu {
   order = 0;
   description = '';
   routeAnchor = '';
+  slug = '';
   @ClassHelper.GetClassConstructor(PageSection)
   pageSections: PageSection[] = [];
   pageSectionsForDelete: string[] = [];

--- a/src/store/modules/news/actions.ts
+++ b/src/store/modules/news/actions.ts
@@ -30,13 +30,21 @@ const actions: ActionTree<State, RootState> = {
     const res = await httpClient.get<INews>({ query: `${slug}` });
     commit('set', res);
   },
-  getMain: async ({ commit }): Promise<void> => {
+  getMain: async ({ commit }, fill?: boolean): Promise<void> => {
     const items = await httpClient.get<INewsWithCount[]>({ query: 'main' });
-    commit('setMain', items);
+    if (fill) {
+      commit('setMainOrFill', items);
+    } else {
+      commit('setMain', items);
+    }
   },
-  getSubMain: async ({ commit }): Promise<void> => {
+  getSubMain: async ({ commit }, fill?: boolean): Promise<void> => {
     const items = await httpClient.get<INewsWithCount[]>({ query: 'submain' });
-    commit('setSubMain', items);
+    if (fill) {
+      commit('setSubMainOrFill', items);
+    } else {
+      commit('setSubMain', items);
+    }
   },
   getByMonth: async ({ commit }, filterQuery?: FilterQuery): Promise<void> => {
     const items = await httpClient.get<INewsWithCount[]>({ query: filterQuery ? filterQuery.toUrl() : '' });

--- a/src/store/modules/news/getters.ts
+++ b/src/store/modules/news/getters.ts
@@ -58,6 +58,11 @@ const getters: GetterTree<State, RootState> = {
   calendarNews(state): INews[] {
     return state.calendarNews;
   },
+  mainPageRecentNewsList(state): INews[] {
+    return state.news
+      .filter((item: INews) => item.id !== state.main.id && item.id !== state.subMain1.id && item.id !== state.subMain2.id)
+      .slice(0, 5);
+  },
   calendarMeta(state): ICalendarMeta | undefined {
     return state.calendarMeta;
   },

--- a/src/store/modules/news/mutations.ts
+++ b/src/store/modules/news/mutations.ts
@@ -28,15 +28,38 @@ const mutations: MutationTree<State> = {
   setMain(state, items: INewsWithCount) {
     state.main = new News(items.news[0]);
   },
+  setMainOrFill(state, items: INewsWithCount) {
+    const main = new News(items.news[0]);
+    if (!main.id) {
+      state.main = state.news.filter((item: INews) => item.id !== state.subMain1.id && item.id !== state.subMain2.id)[0];
+    } else {
+      state.main = main;
+    }
+  },
+  setSubMain1(state, items: INewsWithCount) {
+    state.subMain1 = new News(items.news[0]);
+  },
+  setSubMain2(state, items: INewsWithCount) {
+    state.subMain2 = new News(items.news[0]);
+  },
   setSubMain(state, items: INewsWithCount) {
     state.subMain1 = new News(items.news[0]);
     state.subMain2 = new News(items.news[1]);
   },
-  setSubMain1(state, item: INews) {
-    state.subMain1 = new News(item);
-  },
-  setSubMain2(state, item: INews) {
-    state.subMain2 = new News(item);
+  setSubMainOrFill(state, items: INewsWithCount) {
+    const subMain1 = new News(items.news[0]);
+    if (!subMain1.id) {
+      state.subMain1 = state.news.filter((item: INews) => item.id !== state.main.id && item.id !== state.subMain2.id)[0];
+    } else {
+      state.subMain1 = subMain1;
+    }
+
+    const subMain2 = new News(items.news[1]);
+    if (!subMain2.id) {
+      state.subMain2 = state.news.filter((item: INews) => item.id !== state.main.id && item.id !== state.subMain1.id)[0];
+    } else {
+      state.subMain2 = subMain2;
+    }
   },
   appendToAll(state, items: INewsWithCount) {
     const itemsForAdding = items.news.map((i: INews) => new News(i));
@@ -51,7 +74,6 @@ const mutations: MutationTree<State> = {
   },
   set(state, item?: INews) {
     state.newsItem = new News(item);
-    state.news = [];
   },
   resetState(state) {
     Object.assign(state, getDefaultState());


### PR DESCRIPTION
1. Пофикшен баг с сортировкой документов в сведениях образовательных организаций на портале.
При добавление документа order не устанавливался (по умолчанию 0). Вывес в конец списка. Вывел order в таблицу для наглядности. Для фикса существующих списков, в тех местах где одинаковые номера у документов, достаточно будет поменять их местами чтобы порядковый номер переназначился.
2.1. Рефакторинг кода для назчанения главной новости.
2.2. Добавлена возможность убрать главную/подглавную новости в админке.
2.3. На главной при отсутствии главной/подглавных новостей, подгружаются последние новости на их место.
2.4. Колонка последних новостей фильтруется от главных/последних или новостей их заменивших.
2.5. Пофикшена ширина фона заголовка главной новости (в случае если заголовок короткий, было не во всю ширину.
2.6. Добавлена возможность убрать совсем главную/подглавные новости в админке.
2.7. Добавлен предпросмотр в модалке назначения главной новости
2.8. Заменены селекты на remoteSearch с добавлением кнопок на назначение главной/подглавных новостей по результату remoteSearch 
2.9. Добавлены кнопки удаления главной/подглавной новостей на карточках предпросмотра.
3. Исправлен формат даты в новостях